### PR TITLE
Sync release workflow with gardenlogin

### DIFF
--- a/.github/workflows/update-gardenctl-v2.yaml
+++ b/.github/workflows/update-gardenctl-v2.yaml
@@ -2,63 +2,153 @@ name: gardenctl-updater
 
 permissions:
   contents: write
-  actions: read
-  repository-projects: write
+  actions:  read
 
 on:
   release:
-    types:
-      - published
+    types: [published]
+
+  # Manual / ad‑hoc trigger
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag (version) to build & dispatch (e.g. v1.2.3) - does not upload binaries to release'
+        required: true
+        type: string
+      skip_build:
+        description: "Skip build send dummy checksums"
+        required: false
+        type: boolean
+        default: true
+      dry_run:
+        description: "Dry run: disable external actions (no uploads/dispatches)"
+        required: false
+        type: boolean
+        default: false
+
 jobs:
   update_gardenctl_in_homebrew_tap_and_chocolatey_packages:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    # ───── Set ref (potential user input) as ENV variable (protects against script injection) ─────
+    env:
+      TAG: ${{ inputs.tag || github.ref_name }}
+      OWNER: ${{ github.repository_owner }}
+
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      # ───── Checkout ─────────────────────────────────────────────────────────
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          go-version: '1.24.4'
-      - name: Build the binary-files
-        id: build_binary_files
+          ref: "refs/tags/${{ env.TAG }}"
+
+      # ───── Go toolchain & cache ─────────────────────────────────────────────
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
+        with:
+          go-version-file: go.mod
+
+      # ───── Build ────────────────────────────────────────────────────────────
+      - name: Build binaries
+        # Always build except when workflow_dispatch and user kept skip_build=true
+        if: github.event_name != 'workflow_dispatch' || inputs.skip_build == false
         run: |
-          sudo apt-get update
-          sudo apt-get install make -y
+          echo "Building binaries for tag: $TAG"
           make build
-          echo "latest_release_filtered_tag=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      # ───── Upload assets (only when there *is* a GitHub Release) ────────────
       - name: Upload binaries to release
-        uses: AButler/upload-release-assets@45be2facf3acc71812c1c17b4cefef5f6e8cac8a # v3.0.1
-        with:
-          files: 'bin/darwin-amd64/gardenctl_v2_darwin_amd64;bin/darwin-arm64/gardenctl_v2_darwin_arm64;bin/linux-amd64/gardenctl_v2_linux_amd64;bin/linux-arm64/gardenctl_v2_linux_arm64;bin/windows-amd64/gardenctl_v2_windows_amd64.exe'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          release-tag: ${{ env.latest_release_filtered_tag }}
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # auth for `gh`
+        run: |
+          gh release upload "$TAG" \
+            bin/darwin-amd64/gardenctl_v2_darwin_amd64 \
+            bin/darwin-arm64/gardenctl_v2_darwin_arm64 \
+            bin/linux-amd64/gardenctl_v2_linux_amd64 \
+            bin/linux-arm64/gardenctl_v2_linux_arm64 \
+            bin/windows-amd64/gardenctl_v2_windows_amd64.exe \
+            --clobber
+
+      # ───── GitHub‑App token (needed for repo‑dispatch) ──────────────────────
       - name: Get token for gardener-github-pkg-mngr app
-        if: github.event.release.prerelease == false
+        if: (github.event_name == 'release' && github.event.release.prerelease == false) || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) 
         id: gardener-github-workflows
-        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e   # v2.0.6
         with:
-          app_id: ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_ID }}
-          private_key: ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_PRIVATE_KEY }}
-      - name: Send update with latest versions to ${{ github.repository_owner }}/homebrew-tap
-        if: github.event.release.prerelease == false
+          app-id:      ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_ID }}
+          private-key: ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_PRIVATE_KEY }}
+          owner:       ${{ env.OWNER }}
+          repositories: |
+            homebrew-tap
+            chocolatey-packages
+
+      # ───── SHA‑256 sums (all in one pass) ───────────────────────────────────
+      - name: Compute checksums
+        if: github.event_name != 'workflow_dispatch' || (inputs.skip_build == false  && inputs.dry_run == false)
         run: |
-          latest_release_filtered_tag=${{ env.latest_release_filtered_tag }}
-          darwin_sha256sum_amd64=$(sha256sum bin/darwin-amd64/gardenctl_v2_darwin_amd64 | awk '{print $1}')
-          darwin_sha256sum_arm64=$(sha256sum bin/darwin-arm64/gardenctl_v2_darwin_arm64 | awk '{print $1}')
-          linux_sha256sum_amd64=$(sha256sum bin/linux-amd64/gardenctl_v2_linux_amd64 | awk '{print $1}')
-          linux_sha256sum_arm64=$(sha256sum bin/linux-arm64/gardenctl_v2_linux_arm64 | awk '{print $1}')
-          data='{"event_type": "update", "client_payload": { "component": "gardenctl-v2", "tag": "'"$latest_release_filtered_tag"'", "darwin_sha_amd64": "'"$darwin_sha256sum_amd64"'", "darwin_sha_arm64": "'"$darwin_sha256sum_arm64"'", "linux_sha_amd64": "'"$linux_sha256sum_amd64"'", "linux_sha_arm64": "'"$linux_sha256sum_arm64"'"}}'
-          echo "${data}"
-          curl -X POST https://api.github.com/repos/${{ github.repository_owner }}/homebrew-tap/dispatches \
-          -H 'Accept: application/vnd.github.everest-preview+json' \
-          -H "Authorization: Token ${{ steps.gardener-github-workflows.outputs.token }}" \
-          --data "${data}"
-      - name: Send update with latest versions to ${{ github.repository_owner }}/chocolatey-packages
-        if: github.event.release.prerelease == false
+          set -euo pipefail
+          echo "DARWIN_SHA_AMD64=$(sha256sum bin/darwin-amd64/gardenctl_v2_darwin_amd64      | awk '{print $1}')" >> "$GITHUB_ENV"
+          echo "DARWIN_SHA_ARM64=$(sha256sum bin/darwin-arm64/gardenctl_v2_darwin_arm64      | awk '{print $1}')" >> "$GITHUB_ENV"
+          echo "LINUX_SHA_AMD64=$(sha256sum bin/linux-amd64/gardenctl_v2_linux_amd64        | awk '{print $1}')" >> "$GITHUB_ENV"
+          echo "LINUX_SHA_ARM64=$(sha256sum bin/linux-arm64/gardenctl_v2_linux_arm64        | awk '{print $1}')" >> "$GITHUB_ENV"
+          echo "WINDOWS_SHA=$(sha256sum     bin/windows-amd64/gardenctl_v2_windows_amd64.exe | awk '{print $1}')" >> "$GITHUB_ENV"
+
+      - name: Use dummy hashes (skip‑build)
+        if: github.event_name == 'workflow_dispatch' && inputs.skip_build == true
         run: |
-          latest_release_filtered_tag=${{ env.latest_release_filtered_tag }}
-          windows_sha256sum=$(sha256sum bin/windows-amd64/gardenctl_v2_windows_amd64.exe | awk '{print $1}')
-          data='{"event_type": "update", "client_payload": { "component": "gardenctl-v2", "tag": "'"$latest_release_filtered_tag"'", "windows_sha": "'"$windows_sha256sum"'"}}'
-          echo "${data}"
-          curl -X POST https://api.github.com/repos/${{ github.repository_owner }}/chocolatey-packages/dispatches \
-          -H 'Accept: application/vnd.github.everest-preview+json' \
-          -H "Authorization: Token ${{ steps.gardener-github-workflows.outputs.token }}" \
-          --data "${data}"
+          set -euo pipefail
+          dummy=dummySHA256sum
+          printf '%s\n' \
+            "DARWIN_SHA_AMD64=$dummy" \
+            "DARWIN_SHA_ARM64=$dummy" \
+            "LINUX_SHA_AMD64=$dummy"  \
+            "LINUX_SHA_ARM64=$dummy"  \
+            "WINDOWS_SHA=$dummy" >> "$GITHUB_ENV"
+
+      # ───── Homebrew tap dispatch ────────────────────────────────────────────
+      - name: Send update to $OWNER/homebrew-tap
+        if: (github.event_name == 'release' && github.event.release.prerelease == false) || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        run: |
+          set -euo pipefail
+          data=$(jq -n \
+            --arg component          "gardenctl-v2" \
+            --arg tag                "$TAG" \
+            --arg darwin_sha_amd64   "$DARWIN_SHA_AMD64" \
+            --arg darwin_sha_arm64   "$DARWIN_SHA_ARM64" \
+            --arg linux_sha_amd64    "$LINUX_SHA_AMD64" \
+            --arg linux_sha_arm64    "$LINUX_SHA_ARM64" \
+            '{event_type:"update",
+              client_payload:{
+                component:$component,
+                tag:$tag,
+                darwin_sha_amd64:$darwin_sha_amd64,
+                darwin_sha_arm64:$darwin_sha_arm64,
+                linux_sha_amd64:$linux_sha_amd64,
+                linux_sha_arm64:$linux_sha_arm64}}')
+          curl -X POST \
+            -H 'Accept: application/vnd.github.everest-preview+json' \
+            -H "Authorization: Bearer ${{ steps.gardener-github-workflows.outputs.token }}" \
+            -d "$data" \
+            "https://api.github.com/repos/$OWNER/homebrew-tap/dispatches"
+
+      # ───── Chocolatey dispatch ──────────────────────────────────────────────
+      - name: Send update to $OWNER/chocolatey-packages
+        if: (github.event_name == 'release' && github.event.release.prerelease == false) || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+        run: |
+          set -euo pipefail
+          data=$(jq -n \
+            --arg component   "gardenctl-v2" \
+            --arg tag         "$TAG" \
+            --arg windows_sha "$WINDOWS_SHA" \
+            '{event_type:"update",
+              client_payload:{
+                component:$component,
+                tag:$tag,
+                windows_sha:$windows_sha}}')
+          curl -X POST \
+            -H 'Accept: application/vnd.github.everest-preview+json' \
+            -H "Authorization: Bearer ${{ steps.gardener-github-workflows.outputs.token }}" \
+            -d "$data" \
+            "https://api.github.com/repos/$OWNER/chocolatey-packages/dispatches"


### PR DESCRIPTION
## Summary
- mirror the gardenlogin release workflow improvements
- add manual trigger options and concurrency settings
- switch to uploading assets via gh
- handle dry-run/skip build cases and repository dispatches

## Testing
- `make lint` *(fails: interrupted due to time)*

------
https://chatgpt.com/codex/tasks/task_e_68820900371c8331b32c851e1b344f02